### PR TITLE
Added bundle analyzer

### DIFF
--- a/starter/files/config/project.js
+++ b/starter/files/config/project.js
@@ -3,3 +3,7 @@
 export const APOLLO = {
   uri: 'https://api.graph.cool/simple/v1/cinomw2r1018601o42x5z69uc',
 };
+
+export const BUNDLE_ANALYZER = {
+  openAnalyzer: false,
+}

--- a/starter/files/kit/webpack/browser_prod.js
+++ b/starter/files/kit/webpack/browser_prod.js
@@ -7,6 +7,8 @@
 // ----------------------
 // IMPORTS
 
+import { join } from 'path';
+
 import webpack from 'webpack';
 import WebpackConfig from 'webpack-config';
 
@@ -17,6 +19,15 @@ import ExtractTextPlugin from 'extract-text-webpack-plugin';
 
 // Compression plugin for generating `.gz` static files
 import CompressionPlugin from 'compression-webpack-plugin';
+
+// Bundle Analyzer plugin for viewing interactive treemap of bundle
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+
+// Our local path configuration, so webpack knows where everything is/goes
+import PATHS from '../../config/paths';
+
+// Project configuration to control build settings
+import { BUNDLE_ANALYZER } from '../../config/project';
 
 // ----------------------
 
@@ -128,5 +139,12 @@ export default new WebpackConfig().extend({
 
     // Fire up CSS extraction
     extractCSS,
+
+    // Output interactive bundle report
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'static',
+      reportFilename: join(PATHS.dist, 'report.html'),
+      openAnalyzer: BUNDLE_ANALYZER.openAnalyzer,
+    }),
   ],
 });

--- a/starter/files/package.json
+++ b/starter/files/package.json
@@ -46,6 +46,7 @@
     "sass-loader": "^6.0.3",
     "style-loader": "^0.16.1",
     "webpack": "^2.3.2",
+    "webpack-bundle-analyzer": "^2.4.0",
     "webpack-config": "^7.0.0",
     "webpack-dev-server": "^2.4.2",
     "webpack-node-externals": "^1.5.4"


### PR DESCRIPTION
Webpack Bundle Analyzer is a tool that would be useful to have in any project that cares about optimizing their bundle size. This setup by default generates a `report.html` inside `dist` on the browser production build. I set the `openAnalzyer: boolean` option to be configured from `config/project.js` so that users can change it without editing `kit`. If set to true, the report will be automatically opened in the users default browser after each build. If it would be better, I can remove the external configuration controls.